### PR TITLE
Call static methods, avoid instantiating autograd.Function objects

### DIFF
--- a/linear_operator/functions/__init__.py
+++ b/linear_operator/functions/__init__.py
@@ -55,7 +55,7 @@ def dsmm(sparse_mat, dense_mat):
     Returns:
         - matrix (b x)mxo - Result
     """
-    return DSMM().apply(sparse_mat, dense_mat)
+    return DSMM.apply(sparse_mat, dense_mat)
 
 
 def matmul(mat, rhs):

--- a/linear_operator/functions/_inv_matmul.py
+++ b/linear_operator/functions/_inv_matmul.py
@@ -19,12 +19,12 @@ def _solve(linear_op, rhs):
 
 class InvMatmul(Function):
     @staticmethod
-    def forward(ctx, representation_tree, has_left, *args):
+    def forward(ctx, linear_op, has_left, *args):
         left_tensor = None
         right_tensor = None
         matrix_args = None
 
-        ctx.representation_tree = representation_tree
+        ctx.representation_tree = linear_op.representation_tree()
         ctx.has_left = has_left
 
         if ctx.has_left:
@@ -32,7 +32,6 @@ class InvMatmul(Function):
         else:
             right_tensor, *matrix_args = args
         orig_right_tensor = right_tensor
-        linear_op = ctx.representation_tree(*matrix_args)
 
         ctx.is_vector = False
         if right_tensor.ndimension() == 1:
@@ -90,7 +89,7 @@ class InvMatmul(Function):
 
             if not ctx.has_left:
                 # Compute self^{-1} grad_output
-                left_solves = InvMatmul.apply(ctx.representation_tree, False, grad_output, *matrix_args)
+                left_solves = InvMatmul.apply(linear_op, False, grad_output, *matrix_args)
 
                 if any(ctx.needs_input_grad[3:]):
                     # We call _quad_form_derivative to compute dl/dK

--- a/linear_operator/functions/_inv_quad.py
+++ b/linear_operator/functions/_inv_quad.py
@@ -24,7 +24,7 @@ class InvQuad(Function):
     """
 
     @staticmethod
-    def forward(ctx, representation_tree, *args):
+    def forward(ctx, linear_op, *args):
         """
         *args - The arguments representing the PSD matrix A (or batch of PSD matrices A)
         If inv_quad is true, the first entry in *args is inv_quad_rhs (Tensor)
@@ -35,9 +35,7 @@ class InvQuad(Function):
         - (Scalar) The log determinant (or None, if logdet is False)
         """
         inv_quad_rhs, *matrix_args = args
-        ctx.representation_tree = representation_tree
-        # Get closure for matmul
-        linear_op = ctx.representation_tree(*matrix_args)
+        ctx.representation_tree = linear_op.representation_tree()
 
         # RHS for inv_quad
         ctx.is_vector = False

--- a/linear_operator/functions/_inv_quad_log_det.py
+++ b/linear_operator/functions/_inv_quad_log_det.py
@@ -21,7 +21,7 @@ class InvQuadLogDet(Function):
     @staticmethod
     def forward(
         ctx,
-        representation_tree,
+        linear_op,
         dtype,
         device,
         matrix_shape,
@@ -45,7 +45,7 @@ class InvQuadLogDet(Function):
         if not (inv_quad or logdet):
             raise RuntimeError("Either inv_quad or logdet must be true (or both)")
 
-        ctx.representation_tree = representation_tree
+        ctx.representation_tree = linear_op.representation_tree()
         ctx.dtype = dtype
         ctx.device = device
         ctx.matrix_shape = matrix_shape
@@ -61,8 +61,6 @@ class InvQuadLogDet(Function):
         else:
             matrix_args = args
 
-        # Get closure for matmul
-        linear_op = ctx.representation_tree(*matrix_args)
         with torch.no_grad():
             preconditioner, precond_lt, logdet_correction = linear_op._preconditioner()
 

--- a/linear_operator/functions/_matmul.py
+++ b/linear_operator/functions/_matmul.py
@@ -7,8 +7,8 @@ from .. import settings
 
 class Matmul(Function):
     @staticmethod
-    def forward(ctx, representation_tree, rhs, *matrix_args):
-        ctx.representation_tree = representation_tree
+    def forward(ctx, linear_op, rhs, *matrix_args):
+        ctx.representation_tree = linear_op.representation_tree()
         orig_rhs = rhs
 
         if rhs.ndimension() == 1:
@@ -17,7 +17,6 @@ class Matmul(Function):
         else:
             is_vector = False
 
-        linear_op = ctx.representation_tree(*matrix_args)
         res = linear_op._matmul(rhs)
 
         to_save = [orig_rhs] + list(matrix_args)

--- a/linear_operator/functions/_root_decomposition.py
+++ b/linear_operator/functions/_root_decomposition.py
@@ -11,7 +11,7 @@ class RootDecomposition(Function):
     @staticmethod
     def forward(
         ctx,
-        representation_tree,
+        linear_op,
         max_iter,
         dtype,
         device,
@@ -31,7 +31,7 @@ class RootDecomposition(Function):
         """
         from ..operators import to_linear_operator
 
-        ctx.representation_tree = representation_tree
+        ctx.representation_tree = linear_op.representation_tree()
         ctx.device = device
         ctx.dtype = dtype
         ctx.matrix_shape = matrix_shape
@@ -42,7 +42,6 @@ class RootDecomposition(Function):
         ctx.initial_vectors = initial_vectors
 
         # Get closure for matmul
-        linear_op = ctx.representation_tree(*matrix_args)
         matmul_closure = linear_op._matmul
         # Do lanczos
         q_mat, t_mat = lanczos.lanczos_tridiag(

--- a/linear_operator/functions/_sqrt_inv_matmul.py
+++ b/linear_operator/functions/_sqrt_inv_matmul.py
@@ -16,9 +16,9 @@ class SqrtInvMatmul(Function):
     """
 
     @staticmethod
-    def forward(ctx, representation_tree, rhs, lhs, *matrix_args):
-        ctx.representation_tree = representation_tree
-        ctx.linear_op = ctx.representation_tree(*matrix_args)
+    def forward(ctx, linear_op, rhs, lhs, *matrix_args):
+        ctx.representation_tree = linear_op.representation_tree()
+        ctx.linear_op = linear_op
 
         if lhs is not None:
             terms = torch.cat([rhs, lhs.transpose(-1, -2)], dim=-1)

--- a/linear_operator/operators/block_linear_operator.py
+++ b/linear_operator/operators/block_linear_operator.py
@@ -49,7 +49,8 @@ class BlockLinearOperator(LinearOperator):
                 positive_block_dim,
             )
 
-        super(BlockLinearOperator, self).__init__(to_linear_operator(base_linear_operator))
+        base_linear_operator = to_linear_operator(base_linear_operator)
+        super(BlockLinearOperator, self).__init__(base_linear_operator)
         self.base_linear_operator = base_linear_operator
 
     @abstractmethod

--- a/linear_operator/operators/linear_operator.py
+++ b/linear_operator/operators/linear_operator.py
@@ -556,7 +556,7 @@ class LinearOperator(ABC):
             (Tensor or LinearOperator): The root of the root decomposition
         """
         res, _ = RootDecomposition.apply(
-            self.representation_tree(),
+            self,
             self._root_decomposition_size(),
             self.dtype,
             self.device,
@@ -593,7 +593,7 @@ class LinearOperator(ABC):
         from .root_linear_operator import RootLinearOperator
 
         roots, inv_roots = RootDecomposition.apply(
-            self.representation_tree(),
+            self,
             self._root_decomposition_size(),
             self.dtype,
             self.device,
@@ -1024,9 +1024,9 @@ class LinearOperator(ABC):
                 )
 
         if left_tensor is None:
-            return InvMatmul.apply(self.representation_tree(), False, right_tensor, *self.representation())
+            return InvMatmul.apply(self, False, right_tensor, *self.representation())
         else:
-            return InvMatmul.apply(self.representation_tree(), True, left_tensor, right_tensor, *self.representation())
+            return InvMatmul.apply(self, True, left_tensor, right_tensor, *self.representation())
 
     def inv_quad(self, tensor, reduce_inv_quad=True) -> torch.Tensor:
         r"""
@@ -1056,7 +1056,7 @@ class LinearOperator(ABC):
             )
 
         args = (tensor.expand(*result_shape[:-2], *tensor.shape[-2:]),) + self.representation()
-        inv_quad_term = InvQuad.apply(self.representation_tree(), *args)
+        inv_quad_term = InvQuad.apply(self, *args)
 
         if reduce_inv_quad:
             inv_quad_term = inv_quad_term.sum(-1)
@@ -1134,7 +1134,7 @@ class LinearOperator(ABC):
         probe_vectors, probe_vector_norms = self._probe_vectors_and_norms()
 
         inv_quad_term, logdet_term = InvQuadLogDet.apply(
-            self.representation_tree(),
+            self,
             self.dtype,
             self.device,
             self.matrix_shape,
@@ -1570,9 +1570,7 @@ class LinearOperator(ABC):
             rhs = rhs.unsqueeze(-1)
             squeeze = True
 
-        sqrt_inv_matmul_res, inv_quad_res = SqrtInvMatmul.apply(
-            self.representation_tree(), rhs, lhs, *self.representation()
-        )
+        sqrt_inv_matmul_res, inv_quad_res = SqrtInvMatmul.apply(self, rhs, lhs, *self.representation())
 
         if squeeze:
             sqrt_inv_matmul_res = sqrt_inv_matmul_res.squeeze(-1)
@@ -1963,7 +1961,7 @@ class LinearOperator(ABC):
 
             return MatmulLinearOperator(self, other)
 
-        return Matmul.apply(self.representation_tree(), other, *self.representation())
+        return Matmul.apply(self, other, *self.representation())
 
     def __mul__(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> "LinearOperator":
         from .zero_linear_operator import ZeroLinearOperator

--- a/linear_operator/operators/linear_operator.py
+++ b/linear_operator/operators/linear_operator.py
@@ -555,8 +555,7 @@ class LinearOperator(ABC):
         Returns:
             (Tensor or LinearOperator): The root of the root decomposition
         """
-        func = RootDecomposition()
-        res, _ = func.apply(
+        res, _ = RootDecomposition.apply(
             self.representation_tree(),
             self._root_decomposition_size(),
             self.dtype,
@@ -593,8 +592,7 @@ class LinearOperator(ABC):
         """
         from .root_linear_operator import RootLinearOperator
 
-        func = RootDecomposition()
-        roots, inv_roots = func.apply(
+        roots, inv_roots = RootDecomposition.apply(
             self.representation_tree(),
             self._root_decomposition_size(),
             self.dtype,
@@ -1025,11 +1023,10 @@ class LinearOperator(ABC):
                     )
                 )
 
-        func = InvMatmul
         if left_tensor is None:
-            return func.apply(self.representation_tree(), False, right_tensor, *self.representation())
+            return InvMatmul.apply(self.representation_tree(), False, right_tensor, *self.representation())
         else:
-            return func.apply(self.representation_tree(), True, left_tensor, right_tensor, *self.representation())
+            return InvMatmul.apply(self.representation_tree(), True, left_tensor, right_tensor, *self.representation())
 
     def inv_quad(self, tensor, reduce_inv_quad=True) -> torch.Tensor:
         r"""
@@ -1059,8 +1056,7 @@ class LinearOperator(ABC):
             )
 
         args = (tensor.expand(*result_shape[:-2], *tensor.shape[-2:]),) + self.representation()
-        func = InvQuad.apply
-        inv_quad_term = func(self.representation_tree(), *args)
+        inv_quad_term = InvQuad.apply(self.representation_tree(), *args)
 
         if reduce_inv_quad:
             inv_quad_term = inv_quad_term.sum(-1)
@@ -1137,9 +1133,7 @@ class LinearOperator(ABC):
 
         probe_vectors, probe_vector_norms = self._probe_vectors_and_norms()
 
-        func = InvQuadLogDet.apply
-
-        inv_quad_term, logdet_term = func(
+        inv_quad_term, logdet_term = InvQuadLogDet.apply(
             self.representation_tree(),
             self.dtype,
             self.device,
@@ -1576,8 +1570,9 @@ class LinearOperator(ABC):
             rhs = rhs.unsqueeze(-1)
             squeeze = True
 
-        func = SqrtInvMatmul()
-        sqrt_inv_matmul_res, inv_quad_res = func.apply(self.representation_tree(), rhs, lhs, *self.representation())
+        sqrt_inv_matmul_res, inv_quad_res = SqrtInvMatmul.apply(
+            self.representation_tree(), rhs, lhs, *self.representation()
+        )
 
         if squeeze:
             sqrt_inv_matmul_res = sqrt_inv_matmul_res.squeeze(-1)
@@ -1968,8 +1963,7 @@ class LinearOperator(ABC):
 
             return MatmulLinearOperator(self, other)
 
-        func = Matmul()
-        return func.apply(self.representation_tree(), other, *self.representation())
+        return Matmul.apply(self.representation_tree(), other, *self.representation())
 
     def __mul__(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> "LinearOperator":
         from .zero_linear_operator import ZeroLinearOperator


### PR DESCRIPTION
This PR
1. Changes the signatures of the various `torch.autograd.Function` `forward` implementations to directly take in the `LinearOperator` instead of just the representation tree and then internally constructing the operator.
2. Makes sure all `apply()` functions are called as static methods rather than instantiating unnecessary `Function` objects.