### PR TITLE
Remove unnecessary representation implementations in MulLinearOperator

### DIFF
--- a/linear_operator/operators/mul_linear_operator.py
+++ b/linear_operator/operators/mul_linear_operator.py
@@ -126,13 +126,3 @@ class MulLinearOperator(LinearOperator):
     def _transpose_nonbatch(self):
         # mul.linear_operator only works with symmetric matrices
         return self
-
-    def representation(self):
-        """
-        Returns the Tensors that are used to define the LinearOperator
-        """
-        res = super(MulLinearOperator, self).representation()
-        return res
-
-    def representation_tree(self):
-        return super(MulLinearOperator, self).representation_tree()


### PR DESCRIPTION
These are null-ops