### PR TITLE
Use postponed eval of type annotations, bump python req to >= 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - main
 
 python:
-  - "3.6"
+  - "3.7"
 env:
   - PYTORCH_VERSION=master
   - PYTORCH_VERSION=stable
@@ -26,6 +26,6 @@ script:
 matrix:
   include:
     - env: PRECOMMIT_CHECK
-      python: "3.6"
+      python: "3.7"
       install: pip install pre-commit; pre-commit install
       script: pre-commit run --files test/**/*.py linear_operator/**/*.py

--- a/linear_operator/functions/__init__.py
+++ b/linear_operator/functions/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ._dsmm import DSMM

--- a/linear_operator/functions/_dsmm.py
+++ b/linear_operator/functions/_dsmm.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from torch.autograd import Function
 
 from ..utils.sparse import bdsmm

--- a/linear_operator/functions/_inv_matmul.py
+++ b/linear_operator/functions/_inv_matmul.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 from torch.autograd import Function
 

--- a/linear_operator/functions/_inv_quad.py
+++ b/linear_operator/functions/_inv_quad.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 from torch.autograd import Function
 

--- a/linear_operator/functions/_inv_quad_log_det.py
+++ b/linear_operator/functions/_inv_quad_log_det.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import warnings
 
 import torch

--- a/linear_operator/functions/_matmul.py
+++ b/linear_operator/functions/_matmul.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from torch.autograd import Function
 
 from .. import settings

--- a/linear_operator/functions/_root_decomposition.py
+++ b/linear_operator/functions/_root_decomposition.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 from torch.autograd import Function
 

--- a/linear_operator/functions/_sqrt_inv_matmul.py
+++ b/linear_operator/functions/_sqrt_inv_matmul.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 from torch.autograd import Function
 

--- a/linear_operator/operators/added_diag_linear_operator.py
+++ b/linear_operator/operators/added_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import warnings
 from typing import Optional, Tuple
 

--- a/linear_operator/operators/batch_repeat_linear_operator.py
+++ b/linear_operator/operators/batch_repeat_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import itertools
 from typing import Optional, Tuple
 

--- a/linear_operator/operators/block_diag_linear_operator.py
+++ b/linear_operator/operators/block_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import torch

--- a/linear_operator/operators/block_interleaved_linear_operator.py
+++ b/linear_operator/operators/block_interleaved_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.memoize import cached

--- a/linear_operator/operators/block_linear_operator.py
+++ b/linear_operator/operators/block_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from abc import abstractmethod
 
 import torch

--- a/linear_operator/operators/cached_cg_linear_operator.py
+++ b/linear_operator/operators/cached_cg_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import warnings
 
 import torch

--- a/linear_operator/operators/cat_linear_operator.py
+++ b/linear_operator/operators/cat_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .. import settings

--- a/linear_operator/operators/chol_linear_operator.py
+++ b/linear_operator/operators/chol_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import typing  # noqa F401
 
 from ..utils.memoize import cached

--- a/linear_operator/operators/constant_mul_linear_operator.py
+++ b/linear_operator/operators/constant_mul_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.memoize import cached

--- a/linear_operator/operators/dense_linear_operator.py
+++ b/linear_operator/operators/dense_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .linear_operator import LinearOperator

--- a/linear_operator/operators/diag_linear_operator.py
+++ b/linear_operator/operators/diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import torch

--- a/linear_operator/operators/interpolated_linear_operator.py
+++ b/linear_operator/operators/interpolated_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils import sparse

--- a/linear_operator/operators/keops_linear_operator.py
+++ b/linear_operator/operators/keops_linear_operator.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
 import torch
 
 from ..utils.getitem import _noop_index

--- a/linear_operator/operators/kronecker_product_added_diag_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_added_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .added_diag_linear_operator import AddedDiagLinearOperator

--- a/linear_operator/operators/kronecker_product_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import operator
 from functools import reduce
 from typing import Optional, Tuple

--- a/linear_operator/operators/linear_operator.py
+++ b/linear_operator/operators/linear_operator.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import functools
 import math
 import warnings
 from abc import ABC, abstractmethod
 from typing import Optional, Tuple, Union
 
-import numpy
+import numpy  # noqa F401
 import torch
 
 from .. import settings, utils
@@ -679,7 +681,7 @@ class LinearOperator(ABC):
         return self.transpose(-1, -2)._matmul(rhs)
 
     @implements(torch.add)
-    def add(self, other: Union[torch.Tensor, "LinearOperator"], alpha: float = None) -> "LinearOperator":
+    def add(self, other: Union[torch.Tensor, "LinearOperator"], alpha: float = None) -> LinearOperator:
         r"""
         Each element of the tensor :attr:`other` is multiplied by the scalar :attr:`alpha`
         and added to each element of the :obj:`~linear_operator.operators.LinearOperator`.
@@ -699,7 +701,7 @@ class LinearOperator(ABC):
         else:
             return self + alpha * other
 
-    def add_diag(self, diag: torch.Tensor) -> "LinearOperator":
+    def add_diag(self, diag: torch.Tensor) -> LinearOperator:
         r"""
         Adds an element to the diagonal of the matrix.
 
@@ -731,7 +733,7 @@ class LinearOperator(ABC):
 
         return AddedDiagLinearOperator(self, diag_tensor)
 
-    def add_jitter(self, jitter_val: float = 1e-3) -> "LinearOperator":
+    def add_jitter(self, jitter_val: float = 1e-3) -> LinearOperator:
         r"""
         Adds jitter (i.e., a small diagonal component) to the matrix this
         LinearOperator represents.
@@ -756,7 +758,7 @@ class LinearOperator(ABC):
         return self.shape[:-2]
 
     @implements(torch.cholesky)
-    def cholesky(self, upper: bool = False) -> "LinearOperator":
+    def cholesky(self, upper: bool = False) -> LinearOperator:
         """
         Cholesky-factorizes the LinearOperator.
 
@@ -787,7 +789,7 @@ class LinearOperator(ABC):
         return self._cholesky_solve(rhs, upper=upper)
 
     @implements(torch.clone)
-    def clone(self) -> "LinearOperator":
+    def clone(self) -> LinearOperator:
         """
         Clones the LinearOperator (creates clones of all underlying tensors)
         """
@@ -795,7 +797,7 @@ class LinearOperator(ABC):
         kwargs = {key: val.clone() if hasattr(val, "clone") else val for key, val in self._kwargs.items()}
         return self.__class__(*args, **kwargs)
 
-    def cpu(self) -> "LinearOperator":
+    def cpu(self) -> LinearOperator:
         """
         :return: A new :obj:`~linear_operator.operators.LinearOperator` identical to :attr:`self`, but on the CPU.
         """
@@ -813,7 +815,7 @@ class LinearOperator(ABC):
                 new_kwargs[name] = val
         return self.__class__(*new_args, **new_kwargs)
 
-    def cuda(self, device_id: str = None) -> "LinearOperator":
+    def cuda(self, device_id: str = None) -> LinearOperator:
         """
         This method operates identically to :func:`torch.nn.Module.cuda`.
 
@@ -840,7 +842,7 @@ class LinearOperator(ABC):
         return self._args[0].device
 
     @implements(torch.detach)
-    def detach(self) -> "LinearOperator":
+    def detach(self) -> LinearOperator:
         """
         Removes the LinearOperator from the current computation graph.
         (In practice, this function removes all Tensors that make up the
@@ -849,7 +851,7 @@ class LinearOperator(ABC):
         return self.clone().detach_()
 
     @implements(torch.detach_)
-    def detach_(self) -> "LinearOperator":
+    def detach_(self) -> LinearOperator:
         """
         An in-place version of :meth:`detach`.
         """
@@ -885,7 +887,7 @@ class LinearOperator(ABC):
         return self.ndimension()
 
     @implements(torch.div)
-    def div(self, other: Union[float, torch.Tensor]) -> "LinearOperator":
+    def div(self, other: Union[float, torch.Tensor]) -> LinearOperator:
         """
         Returns the product of this LinearOperator
         the elementwise reciprocal of another matrix.
@@ -897,7 +899,7 @@ class LinearOperator(ABC):
         """
         return self.__div__(other)
 
-    def double(self) -> "LinearOperator":
+    def double(self) -> LinearOperator:
         """
         This method operates identically to :func:`torch.Tensor.double`.
 
@@ -920,7 +922,7 @@ class LinearOperator(ABC):
     def dtype(self) -> torch.dtype:
         return self._args[0].dtype
 
-    def expand(self, *sizes: Union[torch.Size, Tuple[int]]) -> "LinearOperator":
+    def expand(self, *sizes: Union[torch.Size, Tuple[int]]) -> LinearOperator:
         r"""
         Returns a new view of the self
         :obj:`~linear_operator.operators.LinearOperator` with singleton
@@ -1183,7 +1185,7 @@ class LinearOperator(ABC):
         return torch.Size(self.shape[-2:])
 
     @implements(torch.mul)
-    def mul(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def mul(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> LinearOperator:
         """
         Multiplies the matrix by a constant, or elementwise the matrix by another matrix.
 
@@ -1204,18 +1206,18 @@ class LinearOperator(ABC):
 
     def numel(self) -> int:
         """
-        :rtype: numpy.array
+        :rtype: int
         :return: The number of elements.
         """
         return self.shape.numel()
 
-    def numpy(self) -> numpy.array:
+    def numpy(self) -> numpy.ndarray:  # noqa F811
         """
         :return: The LinearOperator as an evaluated numpy array.
         """
         return self.evaluate().detach().cpu().numpy()
 
-    def permute(self, *dims: Tuple[int]) -> "LinearOperator":
+    def permute(self, *dims: Tuple[int]) -> LinearOperator:
         """
         Returns a view of the original tensor with its dimensions permuted.
 
@@ -1281,7 +1283,7 @@ class LinearOperator(ABC):
 
         return self._prod_batch(dim)
 
-    def repeat(self, *sizes: Union[torch.Size, Tuple[int]]) -> "LinearOperator":
+    def repeat(self, *sizes: Union[torch.Size, Tuple[int]]) -> LinearOperator:
         """
         Repeats this tensor along the specified dimensions.
 
@@ -1347,7 +1349,7 @@ class LinearOperator(ABC):
             if hasattr(arg, "requires_grad"):
                 arg.requires_grad = val
 
-    def requires_grad_(self, val: bool) -> "LinearOperator":
+    def requires_grad_(self, val: bool) -> LinearOperator:
         """
         Sets `requires_grad=val` on all the Tensors that make up the LinearOperator
         This is an inplace operation.
@@ -1359,7 +1361,7 @@ class LinearOperator(ABC):
         return self
 
     @cached(name="root_decomposition")
-    def root_decomposition(self, method: Optional[str] = None) -> "LinearOperator":
+    def root_decomposition(self, method: Optional[str] = None) -> LinearOperator:
         r"""
         Returns a (usually low-rank) root decomposition linear operator of the PSD LinearOperator :math:`\mathbf A`.
         This can be used for sampling from a Gaussian distribution, or for obtaining a
@@ -1422,7 +1424,7 @@ class LinearOperator(ABC):
     @cached(name="root_inv_decomposition")
     def root_inv_decomposition(
         self, initial_vectors: Optional[torch.Tensor] = None, test_vectors: Optional[torch.Tensor] = None
-    ) -> "LinearOperator":
+    ) -> LinearOperator:
         r"""
         Returns a (usually low-rank) inverse root decomposition linear operator
         of the PSD LinearOperator :math:`\mathbf A`.
@@ -1599,7 +1601,7 @@ class LinearOperator(ABC):
             return self[index]
 
     @implements(torch.sub)
-    def sub(self, other: Union[torch.Tensor, "LinearOperator"], alpha: float = None) -> "LinearOperator":
+    def sub(self, other: Union[torch.Tensor, "LinearOperator"], alpha: float = None) -> LinearOperator:
         r"""
         Each element of the tensor :attr:`other` is multiplied by the scalar :attr:`alpha`
         and subtracted to each element of the :obj:`~linear_operator.operators.LinearOperator`.
@@ -1709,7 +1711,7 @@ class LinearOperator(ABC):
             pass
         return self._symeig(eigenvectors=eigenvectors)
 
-    def to(self, device_id: torch.device) -> "LinearOperator":
+    def to(self, device_id: torch.device) -> LinearOperator:
         """
         A device-agnostic method of moving the linear_operator to the specified device.
 
@@ -1731,7 +1733,7 @@ class LinearOperator(ABC):
         return self.__class__(*new_args, **new_kwargs)
 
     @implements(torch.t)
-    def t(self) -> "LinearOperator":
+    def t(self) -> LinearOperator:
         """
         Alias of :meth:`transpose` for a non-batched LinearOperator.
         (Tranposes the two dimensions.)
@@ -1741,7 +1743,7 @@ class LinearOperator(ABC):
         return self.transpose(0, 1)
 
     @implements(torch.transpose)
-    def transpose(self, dim1: int, dim2: int) -> "LinearOperator":
+    def transpose(self, dim1: int, dim2: int) -> LinearOperator:
         """
         Transpose the dimensions :attr:`dim1` and :attr:`dim2` of the LinearOperator.
 
@@ -1781,7 +1783,7 @@ class LinearOperator(ABC):
         return res
 
     @implements(torch.unsqueeze)
-    def unsqueeze(self, dim: int) -> "LinearOperator":
+    def unsqueeze(self, dim: int) -> LinearOperator:
         """
         Inserts a singleton batch dimension of a LinearOperator, specifed by :attr:`dim`.
         Note that :attr:`dim` cannot correspond to matrix dimension of the LinearOperator.
@@ -1840,7 +1842,7 @@ class LinearOperator(ABC):
 
         return samples
 
-    def __add__(self, other: Union[torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def __add__(self, other: Union[torch.Tensor, "LinearOperator"]) -> LinearOperator:
         from .sum_linear_operator import SumLinearOperator
         from .zero_linear_operator import ZeroLinearOperator
         from .diag_linear_operator import DiagLinearOperator
@@ -1861,7 +1863,7 @@ class LinearOperator(ABC):
         else:
             return SumLinearOperator(self, other)
 
-    def __div__(self, other: Union[float, torch.Tensor]) -> "LinearOperator":
+    def __div__(self, other: Union[float, torch.Tensor]) -> LinearOperator:
         from .zero_linear_operator import ZeroLinearOperator
 
         if isinstance(other, ZeroLinearOperator):
@@ -1963,7 +1965,7 @@ class LinearOperator(ABC):
 
         return Matmul.apply(self, other, *self.representation())
 
-    def __mul__(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def __mul__(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> LinearOperator:
         from .zero_linear_operator import ZeroLinearOperator
         from .dense_linear_operator import to_linear_operator
 
@@ -1988,16 +1990,16 @@ class LinearOperator(ABC):
 
         return self._mul_matrix(to_linear_operator(other))
 
-    def __radd__(self, other: Union[torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def __radd__(self, other: Union[torch.Tensor, "LinearOperator"]) -> LinearOperator:
         return self + other
 
-    def __rmul__(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def __rmul__(self, other: Union[float, torch.Tensor, "LinearOperator"]) -> LinearOperator:
         return self.mul(other)
 
-    def __rsub__(self, other: Union[torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def __rsub__(self, other: Union[torch.Tensor, "LinearOperator"]) -> LinearOperator:
         return self.mul(-1) + other
 
-    def __sub__(self, other: Union[torch.Tensor, "LinearOperator"]) -> "LinearOperator":
+    def __sub__(self, other: Union[torch.Tensor, "LinearOperator"]) -> LinearOperator:
         return self + other.mul(-1)
 
     def __torch_function__(self, func, types, args=(), kwargs=None):

--- a/linear_operator/operators/linear_operator_representation_tree.py
+++ b/linear_operator/operators/linear_operator_representation_tree.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 
 class LinearOperatorRepresentationTree(object):
     def __init__(self, linear_op):

--- a/linear_operator/operators/matmul_linear_operator.py
+++ b/linear_operator/operators/matmul_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.broadcasting import _matmul_broadcast_shape, _mul_broadcast_shape, _pad_with_singletons

--- a/linear_operator/operators/mul_linear_operator.py
+++ b/linear_operator/operators/mul_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.broadcasting import _matmul_broadcast_shape

--- a/linear_operator/operators/psd_sum_linear_operator.py
+++ b/linear_operator/operators/psd_sum_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from .sum_linear_operator import SumLinearOperator
 
 

--- a/linear_operator/operators/root_linear_operator.py
+++ b/linear_operator/operators/root_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.broadcasting import _pad_with_singletons

--- a/linear_operator/operators/sum_batch_linear_operator.py
+++ b/linear_operator/operators/sum_batch_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.broadcasting import _pad_with_singletons

--- a/linear_operator/operators/sum_linear_operator.py
+++ b/linear_operator/operators/sum_linear_operator.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+from __future__ import annotations
+
 from torch import Tensor
 
 from ..utils.broadcasting import _mul_broadcast_shape

--- a/linear_operator/operators/toeplitz_linear_operator.py
+++ b/linear_operator/operators/toeplitz_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.toeplitz import sym_toeplitz_derivative_quadratic_form, sym_toeplitz_matmul

--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from typing import Callable, Optional, Tuple, Union
 
 import torch
@@ -78,7 +80,7 @@ class TriangularLinearOperator(LinearOperator):
     def _matmul(self, rhs: Tensor) -> Tensor:
         return self._tensor.matmul(rhs)
 
-    def _mul_constant(self, constant: Tensor) -> "TriangularLinearOperator":
+    def _mul_constant(self, constant: Tensor) -> TriangularLinearOperator:
         return TriangularLinearOperator(self._tensor * constant.unsqueeze(-1), upper=self.upper)
 
     def _root_decomposition(self) -> Allsor:
@@ -94,16 +96,16 @@ class TriangularLinearOperator(LinearOperator):
         # already triangular, can just call inv_matmul for the solve
         return self.inv_matmul(rhs)
 
-    def _sum_batch(self, dim: int) -> "TriangularLinearOperator":
+    def _sum_batch(self, dim: int) -> TriangularLinearOperator:
         return TriangularLinearOperator(self._tensor._sum_batch(dim), upper=self.upper)
 
-    def _transpose_nonbatch(self) -> "TriangularLinearOperator":
+    def _transpose_nonbatch(self) -> TriangularLinearOperator:
         return TriangularLinearOperator(self._tensor._transpose_nonbatch(), upper=not self.upper)
 
-    def abs(self) -> "TriangularLinearOperator":
+    def abs(self) -> TriangularLinearOperator:
         return TriangularLinearOperator(self._tensor.abs(), upper=self.upper)
 
-    def add_diag(self, added_diag: Tensor) -> "TriangularLinearOperator":
+    def add_diag(self, added_diag: Tensor) -> TriangularLinearOperator:
         from .added_diag_linear_operator import AddedDiagLinearOperator
 
         shape = _mul_broadcast_shape(self._diag.shape, added_diag.shape)
@@ -117,7 +119,7 @@ class TriangularLinearOperator(LinearOperator):
     def evaluate(self) -> Tensor:
         return self._tensor.evaluate()
 
-    def exp(self) -> "TriangularLinearOperator":
+    def exp(self) -> TriangularLinearOperator:
         return TriangularLinearOperator(self._tensor.exp(), upper=self.upper)
 
     def inv_matmul(self, right_tensor: Tensor, left_tensor: Optional[Tensor] = None) -> Tensor:
@@ -154,7 +156,7 @@ class TriangularLinearOperator(LinearOperator):
         return inv_quad_term, logdet_term
 
     @cached
-    def inverse(self) -> "TriangularLinearOperator":
+    def inverse(self) -> TriangularLinearOperator:
         eye = torch.eye(self._tensor.size(-1), device=self._tensor.device, dtype=self._tensor.dtype)
         inv = self.inv_matmul(eye)
         return TriangularLinearOperator(inv, upper=self.upper)

--- a/linear_operator/operators/zero_linear_operator.py
+++ b/linear_operator/operators/zero_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils.broadcasting import _mul_broadcast_shape

--- a/linear_operator/settings.py
+++ b/linear_operator/settings.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 

--- a/linear_operator/test/base_test_case.py
+++ b/linear_operator/test/base_test_case.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import os
 import random
 from abc import ABC

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import itertools
 import math
 from abc import abstractmethod

--- a/linear_operator/test/utils.py
+++ b/linear_operator/test/utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from typing import Generator
 

--- a/linear_operator/utils/broadcasting.py
+++ b/linear_operator/utils/broadcasting.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 

--- a/linear_operator/utils/cholesky.py
+++ b/linear_operator/utils/cholesky.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import warnings
 
 import torch

--- a/linear_operator/utils/contour_integral_quad.py
+++ b/linear_operator/utils/contour_integral_quad.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
 import math
 import warnings
 

--- a/linear_operator/utils/deprecation.py
+++ b/linear_operator/utils/deprecation.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import functools
 import warnings
 from unittest.mock import MagicMock

--- a/linear_operator/utils/errors.py
+++ b/linear_operator/utils/errors.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 
 class CachingError(RuntimeError):
     pass

--- a/linear_operator/utils/fft.py
+++ b/linear_operator/utils/fft.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 

--- a/linear_operator/utils/getitem.py
+++ b/linear_operator/utils/getitem.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .. import settings

--- a/linear_operator/utils/grid.py
+++ b/linear_operator/utils/grid.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import math
 from typing import List, Tuple
 

--- a/linear_operator/utils/interpolation.py
+++ b/linear_operator/utils/interpolation.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 from functools import reduce
 from operator import mul
 from typing import List

--- a/linear_operator/utils/lanczos.py
+++ b/linear_operator/utils/lanczos.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .. import settings

--- a/linear_operator/utils/linear_cg.py
+++ b/linear_operator/utils/linear_cg.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import warnings
 
 import torch

--- a/linear_operator/utils/memoize.py
+++ b/linear_operator/utils/memoize.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import functools
 import pickle
 

--- a/linear_operator/utils/minres.py
+++ b/linear_operator/utils/minres.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .. import settings

--- a/linear_operator/utils/pivoted_cholesky.py
+++ b/linear_operator/utils/pivoted_cholesky.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .. import settings

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .broadcasting import _matmul_broadcast_shape

--- a/linear_operator/utils/stochastic_lq.py
+++ b/linear_operator/utils/stochastic_lq.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from .lanczos import lanczos_tridiag

--- a/linear_operator/utils/toeplitz.py
+++ b/linear_operator/utils/toeplitz.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 from ..utils import broadcasting, fft

--- a/linear_operator/utils/transforms.py
+++ b/linear_operator/utils/transforms.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import torch
 
 

--- a/linear_operator/utils/warnings.py
+++ b/linear_operator/utils/warnings.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 
 class ExtraComputationWarning(UserWarning):
     """

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     license="MIT",
     classifiers=["Programming Language :: Python :: 3"],
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=install_requires,
     extras_require={
         "dev": ["black", "twine", "pre-commit"],

--- a/test/functions/test_dsmm.py
+++ b/test/functions/test_dsmm.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/functions/test_inv_matmul.py
+++ b/test/functions/test_inv_matmul.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/functions/test_inv_quad.py
+++ b/test/functions/test_inv_quad.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import os
 import random
 import unittest

--- a/test/functions/test_inv_quad_log_det.py
+++ b/test/functions/test_inv_quad_log_det.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/test/functions/test_matmul.py
+++ b/test/functions/test_matmul.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/functions/test_root_decomposition.py
+++ b/test/functions/test_root_decomposition.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_added_diag_linear_operator.py
+++ b/test/operators/test_added_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_batch_repeat_linear_operator.py
+++ b/test/operators/test_batch_repeat_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_block_diag_linear_operator.py
+++ b/test/operators/test_block_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_block_interleaved_linear_operator.py
+++ b/test/operators/test_block_interleaved_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_cached_cg_linear_operator.py
+++ b/test/operators/test_cached_cg_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import math
 import unittest
 import warnings

--- a/test/operators/test_cat_linear_operator.py
+++ b/test/operators/test_cat_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_chol_linear_operator.py
+++ b/test/operators/test_chol_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_constant_mul_linear_operator.py
+++ b/test/operators/test_constant_mul_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_diag_linear_operator.py
+++ b/test/operators/test_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_interpolated_linear_operator.py
+++ b/test/operators/test_interpolated_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_kronecker_product_added_diag_linear_operator.py
+++ b/test/operators/test_kronecker_product_added_diag_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 from unittest import mock
 

--- a/test/operators/test_kronecker_product_linear_operator.py
+++ b/test/operators/test_kronecker_product_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_matmul_linear_operator.py
+++ b/test/operators/test_matmul_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_mul_linear_operator.py
+++ b/test/operators/test_mul_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_non_linear_operator.py
+++ b/test/operators/test_non_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_psd_sum_linear_operator.py
+++ b/test/operators/test_psd_sum_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_root_linear_operator.py
+++ b/test/operators/test_root_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_sum_batch_linear_operator.py
+++ b/test/operators/test_sum_batch_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_sum_linear_operator.py
+++ b/test/operators/test_sum_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_toeplitz_linear_operator.py
+++ b/test/operators/test_toeplitz_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/operators/test_zero_linear_operator.py
+++ b/test/operators/test_zero_linear_operator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/utils/test_cholesky.py
+++ b/test/utils/test_cholesky.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 import warnings
 

--- a/test/utils/test_fft.py
+++ b/test/utils/test_fft.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import numpy as np

--- a/test/utils/test_getitem.py
+++ b/test/utils/test_getitem.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 from itertools import product
 

--- a/test/utils/test_grid.py
+++ b/test/utils/test_grid.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/utils/test_interpolation.py
+++ b/test/utils/test_interpolation.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/utils/test_lanczos.py
+++ b/test/utils/test_lanczos.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/utils/test_linear_cg.py
+++ b/test/utils/test_linear_cg.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import os
 import random
 import unittest

--- a/test/utils/test_minres.py
+++ b/test/utils/test_minres.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/utils/test_pivoted_cholesky.py
+++ b/test/utils/test_pivoted_cholesky.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import math
 import os
 import random

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch

--- a/test/utils/test_toeplitz.py
+++ b/test/utils/test_toeplitz.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import unittest
 
 import torch


### PR DESCRIPTION
postponed eval of type annotations is nice, and shoudl be useful when adding a bunch more type annotations to the codebase. There is something funky with flake8 and this, so I had to suppress a couple of errors.

Note that this bumps the required python version to >=3.7 which hopefully should be uncontroversial (noone should be on < 3.7 at this point)