### PR TITLE
Return (inv) root of KroneckerProductAddedDiagLinearOperator as lazy

### DIFF
--- a/linear_operator/operators/kronecker_product_added_diag_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_added_diag_linear_operator.py
@@ -24,28 +24,33 @@ class KroneckerProductAddedDiagLinearOperator(AddedDiagLinearOperator):
             raise RuntimeError(
                 "One of the LinearOperators input to AddedDiagLinearOperator must be a DiagLinearOperator!"
             )
+        self._diag_is_constant = isinstance(self.diag_tensor, ConstantDiagLinearOperator)
 
     def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
-        # we want to call the standard InvQuadLogDet to easily get the probe vectors and do the
-        # solve but we only want to cache the probe vectors for the backwards
-        inv_quad_term, _ = super().inv_quad_logdet(
-            inv_quad_rhs=inv_quad_rhs, logdet=False, reduce_inv_quad=reduce_inv_quad
-        )
-        logdet_term = self._logdet() if logdet else None
-        return inv_quad_term, logdet_term
+        if self._diag_is_constant:
+            # we want to call the standard InvQuadLogDet to easily get the probe vectors and do the
+            # solve but we only want to cache the probe vectors for the backwards
+            inv_quad_term, _ = super().inv_quad_logdet(
+                inv_quad_rhs=inv_quad_rhs, logdet=False, reduce_inv_quad=reduce_inv_quad
+            )
+            logdet_term = self._logdet() if logdet else None
+            return inv_quad_term, logdet_term
+        return super().inv_quad_logdet(inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad)
 
     def _logdet(self):
-        # symeig requires computing the eigenvectors so that it's differentiable
-        evals, _ = self.linear_operator.symeig(eigenvectors=True)
-        evals_plus_diag = evals + self.diag_tensor.diag()
-        return torch.log(evals_plus_diag).sum(dim=-1)
+        if self._diag_is_constant:
+            # symeig requires computing the eigenvectors so that it's differentiable
+            evals, _ = self.linear_operator.symeig(eigenvectors=True)
+            evals_plus_diag = evals + self.diag_tensor.diag()
+            return torch.log(evals_plus_diag).sum(dim=-1)
+        return super()._logdet()
 
     def _preconditioner(self):
         # solves don't use CG so don't waste time computing it
         return None, None, None
 
     def _solve(self, rhs, preconditioner=None, num_tridiag=0):
-        if isinstance(self.diag_tensor, ConstantDiagLinearOperator):
+        if self._diag_is_constant:
             # we do the solve in double for numerical stability issues
             # TODO: Use fp64 registry once #1213 is addressed
 
@@ -67,10 +72,10 @@ class KroneckerProductAddedDiagLinearOperator(AddedDiagLinearOperator):
 
         # TODO: implement woodbury formula for non-constant Kronecker-structured diagonal operators
 
-        return super()._solve(rhs, preconditioner=None, num_tridiag=0)
+        return super()._solve(rhs, preconditioner=preconditioner, num_tridiag=num_tridiag)
 
     def _root_decomposition(self):
-        if isinstance(self.diag_tensor, ConstantDiagLinearOperator):
+        if self._diag_is_constant:
             # we can be use eigendecomposition and shift the eigenvalues
             evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
             updated_evals = DiagLinearOperator((evals + self.diag_tensor.diag()).pow(0.5))
@@ -78,7 +83,7 @@ class KroneckerProductAddedDiagLinearOperator(AddedDiagLinearOperator):
         return super()._root_decomposition()
 
     def _root_inv_decomposition(self, initial_vectors=None):
-        if isinstance(self.diag_tensor, ConstantDiagLinearOperator):
+        if self._diag_is_constant:
             evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
             inv_sqrt_evals = DiagLinearOperator((evals + self.diag_tensor.diag()).pow(-0.5))
             return MatmulLinearOperator(q_matrix, inv_sqrt_evals)

--- a/linear_operator/operators/kronecker_product_added_diag_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_added_diag_linear_operator.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 import torch
 
 from .added_diag_linear_operator import AddedDiagLinearOperator
-from .diag_linear_operator import DiagLinearOperator
+from .diag_linear_operator import ConstantDiagLinearOperator, DiagLinearOperator
+from .matmul_linear_operator import MatmulLinearOperator
 
 
 class KroneckerProductAddedDiagLinearOperator(AddedDiagLinearOperator):
     def __init__(self, *linear_operators, preconditioner_override=None):
-        # TODO: implement the woodbury formula for diagonal tensors that are non constants.
-
-        super(KroneckerProductAddedDiagLinearOperator, self).__init__(
-            *linear_operators, preconditioner_override=preconditioner_override
-        )
+        super().__init__(*linear_operators, preconditioner_override=preconditioner_override)
         if len(linear_operators) > 2:
             raise RuntimeError("An AddedDiagLinearOperator can only have two components")
         elif isinstance(linear_operators[0], DiagLinearOperator):
@@ -34,12 +31,7 @@ class KroneckerProductAddedDiagLinearOperator(AddedDiagLinearOperator):
         inv_quad_term, _ = super().inv_quad_logdet(
             inv_quad_rhs=inv_quad_rhs, logdet=False, reduce_inv_quad=reduce_inv_quad
         )
-
-        if logdet is not False:
-            logdet_term = self._logdet()
-        else:
-            logdet_term = None
-
+        logdet_term = self._logdet() if logdet else None
         return inv_quad_term, logdet_term
 
     def _logdet(self):
@@ -53,33 +45,41 @@ class KroneckerProductAddedDiagLinearOperator(AddedDiagLinearOperator):
         return None, None, None
 
     def _solve(self, rhs, preconditioner=None, num_tridiag=0):
-        # we do the solve in double for numerical stability issues
-        # TODO: Use fp64 registry once #1213 is addressed
+        if isinstance(self.diag_tensor, ConstantDiagLinearOperator):
+            # we do the solve in double for numerical stability issues
+            # TODO: Use fp64 registry once #1213 is addressed
 
-        rhs_dtype = rhs.dtype
-        rhs = rhs.double()
+            rhs_dtype = rhs.dtype
+            rhs = rhs.double()
 
-        evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
-        evals, q_matrix = evals.double(), q_matrix.double()
+            evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
+            evals, q_matrix = evals.double(), q_matrix.double()
 
-        evals_plus_diagonal = evals + self.diag_tensor.diag()
-        evals_root = evals_plus_diagonal.pow(0.5)
-        inv_mat_sqrt = DiagLinearOperator(evals_root.reciprocal())
+            evals_plus_diagonal = evals + self.diag_tensor.diag()
+            evals_root = evals_plus_diagonal.pow(0.5)
+            inv_mat_sqrt = DiagLinearOperator(evals_root.reciprocal())
 
-        res = q_matrix.transpose(-2, -1).matmul(rhs)
-        res2 = inv_mat_sqrt.matmul(res)
+            res = q_matrix.transpose(-2, -1).matmul(rhs)
+            res2 = inv_mat_sqrt.matmul(res)
 
-        lhs = q_matrix.matmul(inv_mat_sqrt)
-        return lhs.matmul(res2).type(rhs_dtype)
+            lhs = q_matrix.matmul(inv_mat_sqrt)
+            return lhs.matmul(res2).type(rhs_dtype)
+
+        # TODO: implement woodbury formula for non-constant Kronecker-structured diagonal operators
+
+        return super()._solve(rhs, preconditioner=None, num_tridiag=0)
 
     def _root_decomposition(self):
-        evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
-        updated_evals = DiagLinearOperator((evals + self.diag_tensor.diag()).pow(0.5))
-        matrix_root = q_matrix.matmul(updated_evals)
-        return matrix_root
+        if isinstance(self.diag_tensor, ConstantDiagLinearOperator):
+            # we can be use eigendecomposition and shift the eigenvalues
+            evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
+            updated_evals = DiagLinearOperator((evals + self.diag_tensor.diag()).pow(0.5))
+            return MatmulLinearOperator(q_matrix, updated_evals)
+        return super()._root_decomposition()
 
     def _root_inv_decomposition(self, initial_vectors=None):
-        evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
-        inv_sqrt_evals = DiagLinearOperator((evals + self.diag_tensor.diag()).pow(-0.5))
-        matrix_inv_root = q_matrix.matmul(inv_sqrt_evals)
-        return matrix_inv_root
+        if isinstance(self.diag_tensor, ConstantDiagLinearOperator):
+            evals, q_matrix = self.linear_operator.symeig(eigenvectors=True)
+            inv_sqrt_evals = DiagLinearOperator((evals + self.diag_tensor.diag()).pow(-0.5))
+            return MatmulLinearOperator(q_matrix, inv_sqrt_evals)
+        return super()._root_inv_decomposition(initial_vectors=initial_vectors)

--- a/linear_operator/operators/linear_operator.py
+++ b/linear_operator/operators/linear_operator.py
@@ -1925,7 +1925,7 @@ class LinearOperator(ABC):
         # Alternatively, if we're using tensor indices and losing dimensions, use self._get_indices
         if row_col_are_absorbed:
             # Convert all indices into tensor indices
-            *batch_indices, row_index, col_index, = _convert_indices_to_tensors(
+            (*batch_indices, row_index, col_index,) = _convert_indices_to_tensors(
                 self, (*batch_indices, row_index, col_index)
             )
             res = self._get_indices(row_index, col_index, *batch_indices)

--- a/linear_operator/utils/__init__.py
+++ b/linear_operator/utils/__init__.py
@@ -9,8 +9,7 @@ from .stochastic_lq import StochasticLQ
 
 
 def prod(items):
-    """
-    """
+    """"""
     if len(items):
         res = items[0]
         for item in items[1:]:

--- a/linear_operator/utils/interpolation.py
+++ b/linear_operator/utils/interpolation.py
@@ -156,8 +156,7 @@ class Interpolation(object):
 
 
 def left_interp(interp_indices, interp_values, rhs):
-    """
-    """
+    """"""
     is_vector = rhs.ndimension() == 1
 
     if is_vector:
@@ -181,8 +180,7 @@ def left_interp(interp_indices, interp_values, rhs):
 
 
 def left_t_interp(interp_indices, interp_values, rhs, output_dim):
-    """
-    """
+    """"""
     from .. import dsmm
 
     is_vector = rhs.ndimension() == 1

--- a/linear_operator/utils/lanczos.py
+++ b/linear_operator/utils/lanczos.py
@@ -18,8 +18,7 @@ def lanczos_tridiag(
     num_init_vecs=1,
     tol=1e-5,
 ):
-    """
-    """
+    """"""
     # Determine batch mode
     multiple_init_vecs = False
 

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -140,8 +140,7 @@ def sparse_eye(size):
 
 
 def sparse_getitem(sparse, idxs):
-    """
-    """
+    """"""
     if not isinstance(idxs, tuple):
         idxs = (idxs,)
 
@@ -201,8 +200,7 @@ def sparse_getitem(sparse, idxs):
 
 
 def sparse_repeat(sparse, *repeat_sizes):
-    """
-    """
+    """"""
     if len(repeat_sizes) == 1 and isinstance(repeat_sizes, tuple):
         repeat_sizes = repeat_sizes[0]
 
@@ -243,8 +241,7 @@ def sparse_repeat(sparse, *repeat_sizes):
 
 
 def to_sparse(dense):
-    """
-    """
+    """"""
     mask = dense.ne(0)
     indices = mask.nonzero(as_tuple=False)
     if indices.storage():


### PR DESCRIPTION
This is a clone of https://github.com/cornellius-gp/gpytorch/pull/1430

Previously, `_root_decomposition` and `_inv_root_decomposition` were returning the (inv) root from the eigendecomposition as a dense tensor, which can be inefficient. This now returns the root as `MatmulLazyTensor` instead. E.g. a matrix vector product of the root with some vector `v` is now implicitly computed as `q_matrix @ (evals \dot v)` rather than `(q_matrix @ diag(evals)) @ v`, which can make a big difference since `q_matrix` is a Kronecker product.

This can help runtime, but more importantly it significantly reduces memory footprint, since we don't need to instantiate the (inv) root, but only the constituent components.

This also fixes an issue with `KroneckerProductAddedDiagLinearOperator` implicitly assuming the diagonal to be constant, and returning incorrect results if that was not the case. The changes here make the tensor fall back to the superclass implementation in case of non-constant diagonals.
